### PR TITLE
Add docker compose configuration and Prisma schema

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,11 @@
+# Shared credentials for docker-compose
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=calendarsync
+
+# Application defaults for docker-compose
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=changeme
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+DATABASE_URL=postgresql://postgres:postgres@db:5432/calendarsync?schema=public

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Application
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=changeme
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/calendarsync?schema=public
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=calendarsync

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ prisma/*.db
 
 # Misc
 .DS_Store
+.env
+.env.docker

--- a/README.md
+++ b/README.md
@@ -18,3 +18,29 @@ npm run dev
 
 The app renders a placeholder dashboard and exposes the NextAuth handler under `/api/auth/[...nextauth]`. Subsequent
 milestones will introduce the Prisma schema, database services, and CalendarSync workflow integrations.
+
+## Environment configuration
+
+Copy the provided template to configure local environment variables:
+
+```bash
+cp .env.example .env.local
+```
+
+Update the database credentials or OAuth secrets as needed. The same keys are used by Docker Compose via `.env.docker` (copy the
+example to `.env.docker`).
+
+## Docker Compose stack
+
+The monolithic V1 can be started with PostgreSQL using Docker Compose:
+
+```bash
+cp .env.docker.example .env.docker
+docker compose up --build
+```
+
+Apply Prisma migrations after the services are running:
+
+```bash
+docker compose run --rm web npx prisma migrate deploy
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  web:
+    build:
+      context: .
+    env_file:
+      - .env.docker
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    command: npm run start
+
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-calendarsync}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-calendarsync}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:

--- a/prisma/migrations/20240207000000_init/migration.sql
+++ b/prisma/migrations/20240207000000_init/migration.sql
@@ -1,0 +1,131 @@
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Enum definitions
+CREATE TYPE "SyncJobStatus" AS ENUM ('ACTIVE', 'PAUSED');
+CREATE TYPE "SyncJobCadence" AS ENUM ('FIFTEEN_MINUTES', 'HOURLY', 'DAILY');
+CREATE TYPE "JobRunStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED', 'CANCELLED');
+
+-- Core tables
+CREATE TABLE "User" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "name" TEXT,
+  "email" TEXT,
+  "emailVerified" TIMESTAMP(3),
+  "image" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Account" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "userId" UUID NOT NULL,
+  "type" TEXT NOT NULL,
+  "provider" TEXT NOT NULL,
+  "providerAccountId" TEXT NOT NULL,
+  "refresh_token" TEXT,
+  "access_token" TEXT,
+  "expires_at" INTEGER,
+  "token_type" TEXT,
+  "scope" TEXT,
+  "id_token" TEXT,
+  "session_state" TEXT,
+  "oauth_token_secret" TEXT,
+  "oauth_token" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Session" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "sessionToken" TEXT NOT NULL,
+  "userId" UUID NOT NULL,
+  "expires" TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "VerificationToken" (
+  "identifier" TEXT NOT NULL,
+  "token" TEXT NOT NULL,
+  "expires" TIMESTAMP(3) NOT NULL
+);
+
+CREATE TABLE "Calendar" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "accountId" UUID NOT NULL,
+  "googleCalendarId" TEXT NOT NULL,
+  "summary" TEXT NOT NULL,
+  "timeZone" TEXT NOT NULL,
+  "description" TEXT,
+  "color" TEXT,
+  "accessRole" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Calendar_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "SyncJob" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "ownerId" UUID NOT NULL,
+  "sourceCalendarId" UUID NOT NULL,
+  "destinationCalendarId" UUID NOT NULL,
+  "name" TEXT NOT NULL,
+  "status" "SyncJobStatus" NOT NULL DEFAULT 'ACTIVE',
+  "cadence" "SyncJobCadence" NOT NULL,
+  "config" JSONB,
+  "lastRunAt" TIMESTAMP(3),
+  "nextRunAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SyncJob_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "JobRun" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "jobId" UUID NOT NULL,
+  "status" "JobRunStatus" NOT NULL,
+  "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "finishedAt" TIMESTAMP(3),
+  "message" TEXT,
+  "logLocation" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "JobRun_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+CREATE UNIQUE INDEX "Calendar_accountId_googleCalendarId_key" ON "Calendar"("accountId", "googleCalendarId");
+CREATE INDEX "SyncJob_status_idx" ON "SyncJob"("status");
+CREATE INDEX "SyncJob_cadence_idx" ON "SyncJob"("cadence");
+CREATE INDEX "JobRun_status_idx" ON "JobRun"("status");
+CREATE INDEX "JobRun_jobId_startedAt_idx" ON "JobRun"("jobId", "startedAt");
+
+-- Foreign keys
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Calendar" ADD CONSTRAINT "Calendar_accountId_fkey"
+  FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SyncJob" ADD CONSTRAINT "SyncJob_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SyncJob" ADD CONSTRAINT "SyncJob_sourceCalendarId_fkey"
+  FOREIGN KEY ("sourceCalendarId") REFERENCES "Calendar"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "SyncJob" ADD CONSTRAINT "SyncJob_destinationCalendarId_fkey"
+  FOREIGN KEY ("destinationCalendarId") REFERENCES "Calendar"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "JobRun" ADD CONSTRAINT "JobRun_jobId_fkey"
+  FOREIGN KEY ("jobId") REFERENCES "SyncJob"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,136 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum SyncJobStatus {
+  ACTIVE
+  PAUSED
+}
+
+enum SyncJobCadence {
+  FIFTEEN_MINUTES
+  HOURLY
+  DAILY
+}
+
+enum JobRunStatus {
+  PENDING
+  RUNNING
+  SUCCESS
+  FAILED
+  CANCELLED
+}
+
+model User {
+  id            String    @id @default(uuid()) @db.Uuid
+  name          String?
+  email         String?   @unique
+  emailVerified DateTime?
+  image         String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  accounts      Account[]
+  sessions      Session[]
+  ownedSyncJobs SyncJob[] @relation("SyncJobOwner")
+}
+
+model Account {
+  id                 String   @id @default(uuid()) @db.Uuid
+  userId             String   @db.Uuid
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?
+  access_token       String?
+  expires_at         Int?
+  token_type         String?
+  scope              String?
+  id_token           String?
+  session_state      String?
+  oauth_token_secret String?
+  oauth_token        String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  calendars          Calendar[]
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(uuid()) @db.Uuid
+  sessionToken String   @unique
+  userId       String   @db.Uuid
+  expires      DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Calendar {
+  id                 String    @id @default(uuid()) @db.Uuid
+  accountId          String    @db.Uuid
+  googleCalendarId   String
+  summary            String
+  timeZone           String
+  description        String?
+  color              String?
+  accessRole         String?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  account            Account   @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  sourceForJobs      SyncJob[] @relation("SourceCalendar")
+  destinationForJobs SyncJob[] @relation("DestinationCalendar")
+
+  @@unique([accountId, googleCalendarId])
+}
+
+model SyncJob {
+  id                    String         @id @default(uuid()) @db.Uuid
+  ownerId               String         @db.Uuid
+  sourceCalendarId      String         @db.Uuid
+  destinationCalendarId String         @db.Uuid
+  name                  String
+  status                SyncJobStatus  @default(ACTIVE)
+  cadence               SyncJobCadence
+  config                Json?
+  lastRunAt             DateTime?
+  nextRunAt             DateTime?
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
+  owner                 User           @relation("SyncJobOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  sourceCalendar        Calendar       @relation("SourceCalendar", fields: [sourceCalendarId], references: [id])
+  destinationCalendar   Calendar       @relation("DestinationCalendar", fields: [destinationCalendarId], references: [id])
+  runs                  JobRun[]
+
+  @@index([status])
+  @@index([cadence])
+}
+
+model JobRun {
+  id           String      @id @default(uuid()) @db.Uuid
+  jobId        String      @db.Uuid
+  status       JobRunStatus
+  startedAt    DateTime    @default(now())
+  finishedAt   DateTime?
+  message      String?
+  logLocation  String?
+  createdAt    DateTime    @default(now())
+  job          SyncJob     @relation(fields: [jobId], references: [id], onDelete: Cascade)
+
+  @@index([status])
+  @@index([jobId, startedAt])
+}


### PR DESCRIPTION
## Summary
- add docker compose stack with a Postgres dependency and shared env templates for local configuration
- define the Prisma data model for users, linked accounts, calendars, sync jobs, and job runs
- document how to configure environment files and start the stack with Docker Compose

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e458a25cd88333b3498a13127aba4d