### PR TITLE
Integrate CalendarSync CLI execution helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,23 @@
 FROM node:20-alpine AS base
 WORKDIR /app
 
+FROM base AS calendarsync
+ARG CALENDARSYNC_VERSION=v0.6.2
+ARG CALENDARSYNC_DOWNLOAD_URL
+RUN apk add --no-cache curl tar
+RUN set -eux; \
+  download_url="${CALENDARSYNC_DOWNLOAD_URL:-https://github.com/inovex/CalendarSync/releases/download/${CALENDARSYNC_VERSION}/CalendarSync_${CALENDARSYNC_VERSION#v}_Linux_x86_64.tar.gz}"; \
+  tmpdir="$(mktemp -d)"; \
+  curl -fL "$download_url" -o "$tmpdir/calendarsync.tar.gz"; \
+  tar -xzf "$tmpdir/calendarsync.tar.gz" -C "$tmpdir"; \
+  bin_path="$(find "$tmpdir" -maxdepth 3 -type f -perm -111 | head -n 1)"; \
+  if [ -z "$bin_path" ]; then \
+    echo "Failed to locate CalendarSync binary in archive from $download_url" >&2; \
+    exit 1; \
+  fi; \
+  install -m 0755 "$bin_path" /usr/local/bin/calendarsync; \
+  rm -rf "$tmpdir"
+
 FROM base AS deps
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
 RUN \
@@ -20,10 +37,12 @@ RUN npm run build
 FROM base AS runner
 ENV NODE_ENV=production
 WORKDIR /app
+RUN apk add --no-cache libstdc++
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY package.json ./package.json
+COPY --from=calendarsync /usr/local/bin/calendarsync /usr/local/bin/calendarsync
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Apply Prisma migrations after the services are running:
 ```bash
 docker compose run --rm web npx prisma migrate deploy
 ```
+
+### CalendarSync binary integration
+
+The Docker image now bundles the CalendarSync CLI. The binary is downloaded during the build stage via the
+`CALENDARSYNC_VERSION` build argument (default: `v0.6.2`). If you need to pin to a different release or provide an internal
+mirror, override `CALENDARSYNC_DOWNLOAD_URL` when invoking `docker build`:
+
+```bash
+docker build \
+  --build-arg CALENDARSYNC_VERSION=v0.6.3 \
+  --build-arg CALENDARSYNC_DOWNLOAD_URL=https://example.com/calendarsync.tar.gz \
+  -t calendarsync-app .
+```
+
+Within application code, use the `runCalendarSync` helper from `lib/calendarsync/executor` to generate configuration files and
+stream CLI logs. The helper throws a `CalendarSyncExecutionError` when the process exits with a non-zero status, exposing the
+captured stdout/stderr for debugging.

--- a/lib/calendarsync/executor.ts
+++ b/lib/calendarsync/executor.ts
@@ -1,0 +1,228 @@
+import { spawn } from "child_process";
+import { randomUUID } from "crypto";
+import { access, mkdtemp, rm, writeFile } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import YAML from "yaml";
+
+export const DEFAULT_CALENDARSYNC_BINARY =
+  process.env.CALENDARSYNC_BINARY ?? "/usr/local/bin/calendarsync";
+
+export interface CalendarSyncConfig {
+  [key: string]: unknown;
+}
+
+export interface CalendarSyncExecutionOptions {
+  /**
+   * Path to the CalendarSync executable. Defaults to the value baked into the container image.
+   */
+  binaryPath?: string;
+  /**
+   * Raw configuration mapped to the CalendarSync YAML schema.
+   */
+  config: CalendarSyncConfig;
+  /**
+   * Optional environment overrides for the spawned process.
+   */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Receives stdout log chunks as they are produced by the CLI.
+   */
+  onStdout?: (chunk: string) => void;
+  /**
+   * Receives stderr log chunks as they are produced by the CLI.
+   */
+  onStderr?: (chunk: string) => void;
+  /**
+   * Abort signal to cancel execution. A SIGTERM is sent to the child process on abort.
+   */
+  signal?: AbortSignal | null;
+  /**
+   * Persist the generated configuration file for debugging instead of removing it when the process finishes.
+   */
+  keepConfigFile?: boolean;
+  /**
+   * Allows callers to override the base temporary directory used for config generation.
+   */
+  workingDirectory?: string;
+}
+
+export interface CalendarSyncExecutionResult {
+  /** Exit code returned by the CalendarSync CLI. */
+  exitCode: number | null;
+  /** Signal used to terminate the process, if applicable. */
+  signal: NodeJS.Signals | null;
+  /** Combined stdout output captured during execution. */
+  stdout: string;
+  /** Combined stderr output captured during execution. */
+  stderr: string;
+  /** Elapsed time for the run in milliseconds. */
+  durationMs: number;
+  /** Absolute path to the YAML configuration file used for the run. */
+  configPath: string;
+  /** Path to the CalendarSync binary that was invoked. */
+  binaryPath: string;
+  /** Indicates whether the CLI exited successfully. */
+  success: boolean;
+}
+
+export class CalendarSyncExecutionError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(
+    public readonly result: CalendarSyncExecutionResult,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `CalendarSync execution failed with exit code ${result.exitCode} and signal ${result.signal}`,
+    );
+    this.name = "CalendarSyncExecutionError";
+    this.cause = options?.cause;
+  }
+}
+
+export class CalendarSyncBinaryNotFoundError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(public readonly binaryPath: string, options?: { cause?: unknown }) {
+    super(
+      `CalendarSync binary is not executable or missing at path: ${binaryPath}. Ensure the container image bundles the binary or pass a custom path via CALENDARSYNC_BINARY.`,
+    );
+    this.name = "CalendarSyncBinaryNotFoundError";
+    this.cause = options?.cause;
+  }
+}
+
+/**
+ * Generates a CalendarSync YAML configuration and executes the CLI, streaming logs to the provided callbacks.
+ *
+ * @throws CalendarSyncBinaryNotFoundError when the binary is not present or executable.
+ * @throws CalendarSyncExecutionError when the CLI exits with a non-zero exit code.
+ */
+export async function runCalendarSync({
+  binaryPath = DEFAULT_CALENDARSYNC_BINARY,
+  config,
+  env,
+  onStdout,
+  onStderr,
+  signal,
+  keepConfigFile = false,
+  workingDirectory,
+}: CalendarSyncExecutionOptions): Promise<CalendarSyncExecutionResult> {
+  await ensureBinaryIsExecutable(binaryPath);
+
+  const baseDir = workingDirectory ?? tmpdir();
+  const tempDir = await mkdtemp(join(baseDir, "calendarsync-"));
+  const configPath = join(tempDir, `${randomUUID()}.yaml`);
+  const yamlContent = YAML.stringify(config);
+  await writeFile(configPath, yamlContent, "utf8");
+
+  const startTime = Date.now();
+  const child = spawn(binaryPath, ["--config", configPath], {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  const abortSignal = signal ?? null;
+  const abortHandler = () => {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+    }
+  };
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      abortHandler();
+    } else {
+      abortSignal.addEventListener("abort", abortHandler, { once: true });
+    }
+  }
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+    onStdout?.(chunk);
+  });
+
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+    onStderr?.(chunk);
+  });
+
+  try {
+    const result = await new Promise<CalendarSyncExecutionResult>((resolve, reject) => {
+      child.once("error", async (error) => {
+        try {
+          await cleanupTempFiles(tempDir, keepConfigFile);
+        } finally {
+          reject(error);
+        }
+      });
+
+      child.once("close", async (code, termSignal) => {
+        const durationMs = Date.now() - startTime;
+        const executionResult: CalendarSyncExecutionResult = {
+          exitCode: code,
+          signal: termSignal,
+          stdout,
+          stderr,
+          durationMs,
+          configPath,
+          binaryPath,
+          success: code === 0,
+        };
+
+        let cleanupError: unknown;
+        try {
+          await cleanupTempFiles(tempDir, keepConfigFile);
+        } catch (error) {
+          cleanupError = error;
+        }
+
+        if (executionResult.success) {
+          if (cleanupError) {
+            reject(cleanupError as Error);
+            return;
+          }
+
+          resolve(executionResult);
+        } else {
+          const executionError = new CalendarSyncExecutionError(executionResult, {
+            cause: cleanupError,
+          });
+          reject(executionError);
+        }
+      });
+    });
+
+    return result;
+  } finally {
+    if (abortSignal) {
+      abortSignal.removeEventListener("abort", abortHandler);
+    }
+  }
+}
+
+async function ensureBinaryIsExecutable(binaryPath: string): Promise<void> {
+  try {
+    await access(binaryPath, fsConstants.X_OK);
+  } catch (error) {
+    throw new CalendarSyncBinaryNotFoundError(binaryPath, { cause: error });
+  }
+}
+
+async function cleanupTempFiles(directory: string, keepConfigFile: boolean): Promise<void> {
+  if (keepConfigFile) {
+    return;
+  }
+
+  await rm(directory, { recursive: true, force: true });
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "14.1.4",
     "next-auth": "^4.24.7",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@types/node": "20.11.16",


### PR DESCRIPTION
## Summary
- download and install the CalendarSync CLI during the Docker build so the runtime image ships with the binary
- add a TypeScript helper that generates CalendarSync YAML configs, executes the CLI via child_process, and streams logs
- document how to override the CalendarSync download during image builds and how to use the new execution helper

## Testing
- npm run lint *(fails: next binary unavailable until dependencies are installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45a39e7f083339a8d31e649c3135b