### PR TITLE
Implement Google authentication gating

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,18 +1,6 @@
 import NextAuth from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
+import { authOptions } from "@/lib/auth";
 
-const handler = NextAuth({
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? ""
-    })
-  ],
-  callbacks: {
-    async session({ session }) {
-      return session;
-    }
-  }
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,9 @@
+import Image from "next/image";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { getAuthSession } from "@/lib/auth";
+import SignInButton from "@/components/sign-in-button";
+import SignOutButton from "@/components/sign-out-button";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -7,11 +11,21 @@ export const metadata: Metadata = {
   description: "Manage Google calendar sync automations"
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children
 }: {
   children: ReactNode;
 }) {
+  const session = await getAuthSession();
+  const user = session?.user;
+  const fallbackLabel = user?.name ?? user?.email ?? "?";
+  const userInitials = fallbackLabel
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("")
+    .slice(0, 2) || "?";
+
   return (
     <html lang="en">
       <body className="bg-slate-950 text-slate-100">
@@ -24,9 +38,40 @@ export default function RootLayout({
                 </span>
                 <h1 className="text-xl font-bold">Kitchen Sync Dashboard</h1>
               </div>
-              <span className="rounded-full border border-emerald-400/40 px-4 py-1 text-xs font-medium text-emerald-300">
-                V1 Scaffold
-              </span>
+              <div className="flex items-center gap-3">
+                <span className="rounded-full border border-emerald-400/40 px-4 py-1 text-xs font-medium text-emerald-300">
+                  V1 Scaffold
+                </span>
+                {user ? (
+                  <div className="flex items-center gap-3">
+                    {user.image ? (
+                      <Image
+                        src={user.image}
+                        alt={user.name ?? user.email ?? "Authenticated user"}
+                        width={40}
+                        height={40}
+                        className="h-10 w-10 rounded-full border border-emerald-500/40"
+                        priority
+                      />
+                    ) : (
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-emerald-500/40 bg-emerald-500/10 text-sm font-semibold text-emerald-200">
+                        {userInitials}
+                      </div>
+                    )}
+                    <div className="hidden text-right sm:block">
+                      <p className="text-sm font-medium text-emerald-200">
+                        {user.name ?? user.email}
+                      </p>
+                      {user.email ? (
+                        <p className="text-xs text-slate-400">{user.email}</p>
+                      ) : null}
+                    </div>
+                    <SignOutButton />
+                  </div>
+                ) : (
+                  <SignInButton />
+                )}
+              </div>
             </div>
           </header>
           <main className="mx-auto max-w-5xl px-6 py-12">{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,20 @@
-export default function HomePage() {
+import { redirect } from "next/navigation";
+import { getAuthSession } from "@/lib/auth";
+
+export default async function HomePage() {
+  const session = await getAuthSession();
+
+  if (!session) {
+    redirect("/signin");
+  }
+
+  const displayName = session.user?.name ?? session.user?.email ?? "there";
+
   return (
     <div className="space-y-10">
       <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-emerald-500/5">
         <h2 className="text-2xl font-semibold text-emerald-300">Welcome to Kitchen Sync</h2>
+        <p className="mt-2 text-sm text-slate-400">Signed in as {displayName}.</p>
         <p className="mt-4 text-slate-300">
           This Next.js scaffold combines Tailwind CSS styling, next-auth authentication hooks, and Prisma ORM integrations.
           It serves as the foundation for orchestrating Google-to-Google calendar synchronization using the CalendarSync CLI.

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+import SignInButton from "@/components/sign-in-button";
+import { getAuthSession } from "@/lib/auth";
+
+export const metadata = {
+  title: "Sign in | CalendarSync Automations"
+};
+
+export default async function SignInPage() {
+  const session = await getAuthSession();
+
+  if (session) {
+    redirect("/");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center justify-center gap-8 text-center">
+      <div className="space-y-3">
+        <h2 className="text-3xl font-semibold text-emerald-300">Access Kitchen Sync</h2>
+        <p className="text-sm text-slate-300">
+          Sign in with your Google account to manage CalendarSync automation jobs. Authentication is required to protect your
+          schedules and connected calendars.
+        </p>
+      </div>
+      <SignInButton className="px-6 py-2.5" />
+      <p className="text-xs text-slate-500">
+        By continuing you agree to securely share your Google profile information for session management.
+      </p>
+    </div>
+  );
+}

--- a/components/sign-in-button.tsx
+++ b/components/sign-in-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTransition } from "react";
+import { signIn } from "next-auth/react";
+
+type SignInButtonProps = {
+  className?: string;
+};
+
+export default function SignInButton({ className }: SignInButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        startTransition(() => {
+          void signIn("google", { callbackUrl: "/" });
+        })
+      }
+      className={`inline-flex items-center gap-2 rounded-full border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-400/10 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 focus:ring-offset-2 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60 ${className ?? ""}`}
+      disabled={isPending}
+    >
+      <svg
+        aria-hidden
+        className="h-4 w-4"
+        viewBox="0 0 533.5 544.3"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M533.5 278.4c0-17.4-1.5-34.1-4.4-50.3H272v95.2h147.6c-6.4 34.6-26.1 63.8-55.6 83.5v69.4h89.7c52.6-48.5 80.8-120 80.8-197.8z"
+          fill="#4285f4"
+        />
+        <path
+          d="M272 544.3c73.7 0 135.6-24.4 180.8-66.1l-89.7-69.4c-24.9 16.7-56.8 26.5-91.1 26.5-69.9 0-129-47.2-150.1-110.7H29.3v69.9C74.4 487.7 167.5 544.3 272 544.3z"
+          fill="#34a853"
+        />
+        <path
+          d="M121.9 324.6c-4.7-14.1-7.4-29.1-7.4-44.6s2.7-30.5 7.4-44.6V165.5h-92.6C10.6 207.6 0 251.7 0 300c0 48.3 10.6 92.4 29.3 134.5l92.6-71.7z"
+          fill="#fbbc05"
+        />
+        <path
+          d="M272 107.7c40.1 0 76 13.8 104.3 40.9l78.1-78.1C407.5 24.5 345.6 0 272 0 167.5 0 74.4 56.6 29.3 165.5l92.6 69.9C143 154.9 202.1 107.7 272 107.7z"
+          fill="#ea4335"
+        />
+      </svg>
+      {isPending ? "Redirecting…" : "Sign in with Google"}
+    </button>
+  );
+}

--- a/components/sign-out-button.tsx
+++ b/components/sign-out-button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useTransition } from "react";
+import { signOut } from "next-auth/react";
+
+type SignOutButtonProps = {
+  className?: string;
+};
+
+export default function SignOutButton({ className }: SignOutButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        startTransition(() => {
+          void signOut({ callbackUrl: "/signin" });
+        })
+      }
+      className={`inline-flex items-center gap-2 rounded-full border border-slate-800 bg-slate-900 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-emerald-400/80 hover:text-emerald-200 focus:outline-none focus:ring-2 focus:ring-emerald-400/60 focus:ring-offset-2 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-60 ${className ?? ""}`}
+      disabled={isPending}
+    >
+      {isPending ? "Signing out…" : "Sign out"}
+    </button>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,74 @@
+import { getServerSession } from "next-auth";
+import type { NextAuthOptions } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const nextAuthSecret = process.env.NEXTAUTH_SECRET;
+
+if (!googleClientId || !googleClientSecret) {
+  throw new Error(
+    "Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET to use Google authentication."
+  );
+}
+
+if (!nextAuthSecret) {
+  throw new Error(
+    "Missing NEXTAUTH_SECRET environment variable. Set NEXTAUTH_SECRET to secure NextAuth sessions."
+  );
+}
+
+export const authOptions: NextAuthOptions = {
+  secret: nextAuthSecret,
+  session: {
+    strategy: "jwt"
+  },
+  pages: {
+    signIn: "/signin"
+  },
+  providers: [
+    GoogleProvider({
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
+      authorization: {
+        params: {
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code"
+        }
+      }
+    })
+  ],
+  callbacks: {
+    async jwt({ token }) {
+      if (token.sub) {
+        token.userId = token.sub;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.userId ?? "";
+      }
+      return session;
+    }
+  },
+  cookies: {
+    sessionToken: {
+      name:
+        process.env.NODE_ENV === "production"
+          ? "__Secure-next-auth.session-token"
+          : "next-auth.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: process.env.NODE_ENV === "production"
+      }
+    }
+  }
+};
+
+export function getAuthSession() {
+  return getServerSession(authOptions);
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com"
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com"
+      }
+    ]
+  }
 };
 
 module.exports = nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
   "exclude": ["node_modules"]

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,15 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    userId?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize NextAuth configuration for Google OAuth with secure JWT session cookies
- gate the dashboard behind authenticated Google sessions and surface sign-in/sign-out controls
- add a dedicated sign-in route and type augmentation to expose user identifiers in sessions

## Testing
- npm run lint *(fails: `next` missing because registry access for npm install is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45b6f86ac8333b16fe3fdb28fafec