### PR TITLE
feat: add calendar and sync job APIs

### DIFF
--- a/app/api/calendars/route.ts
+++ b/app/api/calendars/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { getAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const SAFE_ACCOUNT_FIELDS = {
+  id: true,
+  provider: true,
+  providerAccountId: true,
+  type: true,
+  createdAt: true,
+  updatedAt: true
+} as const;
+
+export async function GET() {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const calendars = await prisma.calendar.findMany({
+    where: {
+      account: {
+        userId: session.user.id
+      }
+    },
+    orderBy: {
+      summary: "asc"
+    },
+    include: {
+      account: {
+        select: SAFE_ACCOUNT_FIELDS
+      }
+    }
+  });
+
+  return NextResponse.json(calendars);
+}
+
+export async function POST(request: Request) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const {
+    accountId,
+    googleCalendarId,
+    summary,
+    timeZone,
+    description,
+    color,
+    accessRole
+  } = body ?? {};
+
+  if (!accountId || !googleCalendarId || !summary || !timeZone) {
+    return NextResponse.json(
+      {
+        error:
+          "Missing required fields. Provide accountId, googleCalendarId, summary, and timeZone."
+      },
+      { status: 400 }
+    );
+  }
+
+  const account = await prisma.account.findFirst({
+    where: {
+      id: accountId,
+      userId: session.user.id
+    },
+    select: {
+      id: true
+    }
+  });
+
+  if (!account) {
+    return NextResponse.json(
+      { error: "Account not found or access denied." },
+      { status: 404 }
+    );
+  }
+
+  const calendar = await prisma.calendar.upsert({
+    where: {
+      accountId_googleCalendarId: {
+        accountId,
+        googleCalendarId
+      }
+    },
+    update: {
+      summary,
+      timeZone,
+      description,
+      color,
+      accessRole
+    },
+    create: {
+      accountId,
+      googleCalendarId,
+      summary,
+      timeZone,
+      description,
+      color,
+      accessRole
+    },
+    include: {
+      account: {
+        select: SAFE_ACCOUNT_FIELDS
+      }
+    }
+  });
+
+  const status = calendar.createdAt.getTime() === calendar.updatedAt.getTime() ? 201 : 200;
+
+  return NextResponse.json(calendar, { status });
+}

--- a/app/api/sync-jobs/[id]/route.ts
+++ b/app/api/sync-jobs/[id]/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from "next/server";
+import { SyncJobCadence, SyncJobStatus } from "@prisma/client";
+import { getAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type UpdatePayload = {
+  name?: string;
+  sourceCalendarId?: string;
+  destinationCalendarId?: string;
+  cadence?: SyncJobCadence;
+  status?: SyncJobStatus;
+  config?: Record<string, unknown> | null;
+  lastRunAt?: string | null;
+  nextRunAt?: string | null;
+};
+
+function isValidCadence(value: unknown): value is SyncJobCadence {
+  return (
+    typeof value === "string" &&
+    Object.values(SyncJobCadence).includes(value as SyncJobCadence)
+  );
+}
+
+function isValidStatus(value: unknown): value is SyncJobStatus {
+  return (
+    typeof value === "string" &&
+    Object.values(SyncJobStatus).includes(value as SyncJobStatus)
+  );
+}
+
+async function ensureJobOwner(jobId: string, userId: string) {
+  const job = await prisma.syncJob.findFirst({
+    where: {
+      id: jobId,
+      ownerId: userId
+    },
+    include: {
+      sourceCalendar: true,
+      destinationCalendar: true
+    }
+  });
+
+  return job;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await ensureJobOwner(params.id, session.user.id);
+
+  if (!job) {
+    return NextResponse.json({ error: "Sync job not found." }, { status: 404 });
+  }
+
+  return NextResponse.json(job);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await ensureJobOwner(params.id, session.user.id);
+
+  if (!job) {
+    return NextResponse.json({ error: "Sync job not found." }, { status: 404 });
+  }
+
+  const rawBody = await request.json();
+  const body = (rawBody ?? {}) as UpdatePayload;
+
+  if (
+    body.cadence !== undefined &&
+    body.cadence !== null &&
+    !isValidCadence(body.cadence)
+  ) {
+    return NextResponse.json(
+      { error: "Invalid cadence provided." },
+      { status: 400 }
+    );
+  }
+
+  if (body.status !== undefined && body.status !== null && !isValidStatus(body.status)) {
+    return NextResponse.json(
+      { error: "Invalid status provided." },
+      { status: 400 }
+    );
+  }
+
+  const data: Record<string, unknown> = {};
+
+  if (body.name !== undefined) {
+    data.name = body.name;
+  }
+  if (body.cadence !== undefined) {
+    data.cadence = body.cadence;
+  }
+  if (body.status !== undefined) {
+    data.status = body.status;
+  }
+  if (body.config !== undefined) {
+    data.config = body.config;
+  }
+  if (body.lastRunAt !== undefined) {
+    data.lastRunAt = body.lastRunAt ? new Date(body.lastRunAt) : null;
+  }
+  if (body.nextRunAt !== undefined) {
+    data.nextRunAt = body.nextRunAt ? new Date(body.nextRunAt) : null;
+  }
+
+  if (
+    body.sourceCalendarId ||
+    body.destinationCalendarId
+  ) {
+    const calendarIds = [
+      body.sourceCalendarId ?? job.sourceCalendarId,
+      body.destinationCalendarId ?? job.destinationCalendarId
+    ];
+
+    const calendars = await prisma.calendar.findMany({
+      where: {
+        id: {
+          in: calendarIds
+        },
+        account: {
+          userId: session.user.id
+        }
+      },
+      select: {
+        id: true
+      }
+    });
+
+    if (calendars.length !== 2) {
+      return NextResponse.json(
+        {
+          error: "Source and destination calendars must belong to the authenticated user."
+        },
+        { status: 403 }
+      );
+    }
+
+    if (body.sourceCalendarId) {
+      data.sourceCalendarId = body.sourceCalendarId;
+    }
+    if (body.destinationCalendarId) {
+      data.destinationCalendarId = body.destinationCalendarId;
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json(job);
+  }
+
+  const updated = await prisma.syncJob.update({
+    where: { id: job.id },
+    data,
+    include: {
+      sourceCalendar: true,
+      destinationCalendar: true
+    }
+  });
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await ensureJobOwner(params.id, session.user.id);
+
+  if (!job) {
+    return NextResponse.json({ error: "Sync job not found." }, { status: 404 });
+  }
+
+  await prisma.syncJob.delete({
+    where: { id: job.id }
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/sync-jobs/[id]/runs/route.ts
+++ b/app/api/sync-jobs/[id]/runs/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { JobRunStatus } from "@prisma/client";
+import { getAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type CreateJobRunPayload = {
+  status?: JobRunStatus;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  message?: string | null;
+  logLocation?: string | null;
+};
+
+function isValidStatus(value: unknown): value is JobRunStatus {
+  return (
+    typeof value === "string" &&
+    Object.values(JobRunStatus).includes(value as JobRunStatus)
+  );
+}
+
+async function ensureJobAccess(jobId: string, userId: string) {
+  return prisma.syncJob.findFirst({
+    where: {
+      id: jobId,
+      ownerId: userId
+    },
+    select: {
+      id: true
+    }
+  });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await ensureJobAccess(params.id, session.user.id);
+
+  if (!job) {
+    return NextResponse.json({ error: "Sync job not found." }, { status: 404 });
+  }
+
+  const runs = await prisma.jobRun.findMany({
+    where: {
+      jobId: job.id
+    },
+    orderBy: {
+      startedAt: "desc"
+    }
+  });
+
+  return NextResponse.json(runs);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await ensureJobAccess(params.id, session.user.id);
+
+  if (!job) {
+    return NextResponse.json({ error: "Sync job not found." }, { status: 404 });
+  }
+
+  const rawBody = await request.json();
+  const body = (rawBody ?? {}) as CreateJobRunPayload;
+
+  if (!isValidStatus(body.status)) {
+    return NextResponse.json(
+      { error: "Invalid status provided." },
+      { status: 400 }
+    );
+  }
+
+  const run = await prisma.jobRun.create({
+    data: {
+      jobId: job.id,
+      status: body.status,
+      startedAt: body.startedAt ? new Date(body.startedAt) : undefined,
+      finishedAt: body.finishedAt ? new Date(body.finishedAt) : undefined,
+      message: body.message ?? null,
+      logLocation: body.logLocation ?? null
+    }
+  });
+
+  return NextResponse.json(run, { status: 201 });
+}

--- a/app/api/sync-jobs/route.ts
+++ b/app/api/sync-jobs/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { SyncJobCadence, SyncJobStatus } from "@prisma/client";
+import { getAuthSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+type CreateSyncJobPayload = {
+  name?: string;
+  sourceCalendarId?: string;
+  destinationCalendarId?: string;
+  cadence?: SyncJobCadence;
+  status?: SyncJobStatus;
+  config?: Record<string, unknown> | null;
+};
+
+function isValidCadence(value: unknown): value is SyncJobCadence {
+  return (
+    typeof value === "string" &&
+    Object.values(SyncJobCadence).includes(value as SyncJobCadence)
+  );
+}
+
+function isValidStatus(value: unknown): value is SyncJobStatus {
+  return (
+    typeof value === "string" &&
+    Object.values(SyncJobStatus).includes(value as SyncJobStatus)
+  );
+}
+
+export async function GET() {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const jobs = await prisma.syncJob.findMany({
+    where: {
+      ownerId: session.user.id
+    },
+    orderBy: {
+      createdAt: "desc"
+    },
+    include: {
+      sourceCalendar: true,
+      destinationCalendar: true
+    }
+  });
+
+  return NextResponse.json(jobs);
+}
+
+export async function POST(request: Request) {
+  const session = await getAuthSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rawBody = await request.json();
+  const body = (rawBody ?? {}) as CreateSyncJobPayload;
+  const {
+    name,
+    sourceCalendarId,
+    destinationCalendarId,
+    cadence,
+    status,
+    config
+  } = body ?? {};
+
+  if (!name || !sourceCalendarId || !destinationCalendarId) {
+    return NextResponse.json(
+      {
+        error:
+          "Missing required fields. Provide name, sourceCalendarId, and destinationCalendarId."
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidCadence(cadence)) {
+    return NextResponse.json(
+      { error: "Invalid cadence provided." },
+      { status: 400 }
+    );
+  }
+
+  if (status && !isValidStatus(status)) {
+    return NextResponse.json(
+      { error: "Invalid status provided." },
+      { status: 400 }
+    );
+  }
+
+  const calendars = await prisma.calendar.findMany({
+    where: {
+      id: {
+        in: [sourceCalendarId, destinationCalendarId]
+      },
+      account: {
+        userId: session.user.id
+      }
+    },
+    select: {
+      id: true
+    }
+  });
+
+  if (calendars.length !== 2) {
+    return NextResponse.json(
+      {
+        error: "Source and destination calendars must belong to the authenticated user."
+      },
+      { status: 403 }
+    );
+  }
+
+  const job = await prisma.syncJob.create({
+    data: {
+      ownerId: session.user.id,
+      name,
+      sourceCalendarId,
+      destinationCalendarId,
+      cadence,
+      status: status ?? SyncJobStatus.ACTIVE,
+      config: config ?? null
+    },
+    include: {
+      sourceCalendar: true,
+      destinationCalendar: true
+    }
+  });
+
+  return NextResponse.json(job, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- add calendar API route for listing and upserting authenticated users' calendars via Prisma
- expose sync job REST endpoints for managing jobs with ownership validation and calendar checks
- add job run history endpoints for retrieving and recording execution results per sync job

## Testing
- npm run lint *(fails: Next.js binary unavailable because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45e3cccf883338b7ab7cee03da387