### PR TITLE
feat: add telemetry instrumentation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
+import AnalyticsOverview from "@/components/analytics-overview";
 import LinkGoogleAccountButton from "@/components/link-google-account-button";
 import SyncJobPlanner from "@/components/sync-job-planner";
 import type { CalendarOption } from "@/components/sync-job-planner";
 import { getAuthSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { getAnalyticsSummary, recordPageView } from "@/lib/telemetry";
 
 export default async function HomePage() {
   const session = await getAuthSession();
@@ -11,6 +13,10 @@ export default async function HomePage() {
   if (!session) {
     redirect("/signin");
   }
+
+  await recordPageView("/", session.user?.id ?? undefined);
+
+  const analyticsSummary = await getAnalyticsSummary();
 
   const displayName = session.user?.name ?? session.user?.email ?? "there";
   const linkedAccounts = await prisma.account.findMany({
@@ -137,6 +143,7 @@ export default async function HomePage() {
       <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-8">
         <SyncJobPlanner calendars={calendarOptions} />
       </section>
+      <AnalyticsOverview summary={analyticsSummary} />
       <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-8">
         <h3 className="text-xl font-semibold text-emerald-300">Next Steps</h3>
         <ol className="mt-4 list-decimal space-y-2 pl-6 text-sm text-slate-300">

--- a/components/analytics-overview.tsx
+++ b/components/analytics-overview.tsx
@@ -1,0 +1,56 @@
+import type { AnalyticsSummary } from "@/lib/telemetry";
+
+type AnalyticsOverviewProps = {
+  summary: AnalyticsSummary;
+};
+
+const formatter = new Intl.NumberFormat("en-US");
+
+function formatSuccessRate(rate: number | null) {
+  if (rate === null) {
+    return "--";
+  }
+
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+export default function AnalyticsOverview({ summary }: AnalyticsOverviewProps) {
+  const successRate = formatSuccessRate(summary.jobSuccessRate);
+  const successRateHelper = summary.jobRunSampleSize > 0
+    ? `${summary.jobRunSampleSize} job runs in the last 30 days`
+    : "No completed job runs in the last 30 days";
+
+  return (
+    <section className="rounded-2xl border border-slate-800 bg-slate-900/40 p-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold text-emerald-300">Telemetry snapshot</h3>
+          <p className="mt-1 text-sm text-slate-400">
+            Lightweight analytics to understand engagement and operational health.
+          </p>
+        </div>
+      </div>
+      <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-5">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">All-time page views</dt>
+          <dd className="mt-2 text-2xl font-semibold text-emerald-200">
+            {formatter.format(summary.totalPageViews)}
+          </dd>
+          <p className="mt-1 text-xs text-slate-500">Across all authenticated sessions.</p>
+        </div>
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-5">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Page views (7 days)</dt>
+          <dd className="mt-2 text-2xl font-semibold text-emerald-200">
+            {formatter.format(summary.pageViewsLastSevenDays)}
+          </dd>
+          <p className="mt-1 text-xs text-slate-500">Includes repeat visits for rapid feedback.</p>
+        </div>
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/60 p-5">
+          <dt className="text-xs uppercase tracking-wide text-slate-500">Job success rate (30 days)</dt>
+          <dd className="mt-2 text-2xl font-semibold text-emerald-200">{successRate}</dd>
+          <p className="mt-1 text-xs text-slate-500">{successRateHelper}</p>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/lib/telemetry.ts
+++ b/lib/telemetry.ts
@@ -1,0 +1,75 @@
+import { JobRunStatus, TelemetryEventType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+function getDateDaysAgo(days: number) {
+  const now = new Date();
+  now.setUTCDate(now.getUTCDate() - days);
+  return now;
+}
+
+export async function recordPageView(route: string, userId?: string) {
+  try {
+    await prisma.telemetryEvent.create({
+      data: {
+        eventType: TelemetryEventType.PAGE_VIEW,
+        route,
+        userId,
+      }
+    });
+  } catch (error) {
+    console.error("Failed to record page view", { error });
+  }
+}
+
+export type AnalyticsSummary = {
+  totalPageViews: number;
+  pageViewsLastSevenDays: number;
+  jobRunSampleSize: number;
+  jobSuccessRate: number | null;
+};
+
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+  const sevenDaysAgo = getDateDaysAgo(7);
+  const thirtyDaysAgo = getDateDaysAgo(30);
+
+  const [totalPageViews, pageViewsLastSevenDays, completedRuns, successfulRuns] = await Promise.all([
+    prisma.telemetryEvent.count({
+      where: { eventType: TelemetryEventType.PAGE_VIEW }
+    }),
+    prisma.telemetryEvent.count({
+      where: {
+        eventType: TelemetryEventType.PAGE_VIEW,
+        createdAt: {
+          gte: sevenDaysAgo
+        }
+      }
+    }),
+    prisma.jobRun.count({
+      where: {
+        status: {
+          in: [JobRunStatus.SUCCESS, JobRunStatus.FAILED]
+        },
+        startedAt: {
+          gte: thirtyDaysAgo
+        }
+      }
+    }),
+    prisma.jobRun.count({
+      where: {
+        status: JobRunStatus.SUCCESS,
+        startedAt: {
+          gte: thirtyDaysAgo
+        }
+      }
+    })
+  ]);
+
+  const jobSuccessRate = completedRuns > 0 ? successfulRuns / completedRuns : null;
+
+  return {
+    totalPageViews,
+    pageViewsLastSevenDays,
+    jobRunSampleSize: completedRuns,
+    jobSuccessRate
+  };
+}

--- a/prisma/migrations/20240220000000_telemetry_events/migration.sql
+++ b/prisma/migrations/20240220000000_telemetry_events/migration.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "TelemetryEventType" AS ENUM ('PAGE_VIEW');
+
+CREATE TABLE "TelemetryEvent" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "eventType" "TelemetryEventType" NOT NULL,
+  "route" TEXT NOT NULL,
+  "userId" UUID,
+  "metadata" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TelemetryEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "TelemetryEvent_eventType_createdAt_idx"
+  ON "TelemetryEvent"("eventType", "createdAt");
+
+CREATE INDEX "TelemetryEvent_route_idx"
+  ON "TelemetryEvent"("route");
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,10 @@ enum JobRunStatus {
   CANCELLED
 }
 
+enum TelemetryEventType {
+  PAGE_VIEW
+}
+
 model User {
   id            String    @id @default(uuid()) @db.Uuid
   name          String?
@@ -133,4 +137,16 @@ model JobRun {
 
   @@index([status])
   @@index([jobId, startedAt])
+}
+
+model TelemetryEvent {
+  id        String              @id @default(uuid()) @db.Uuid
+  eventType TelemetryEventType
+  route     String
+  userId    String?             @db.Uuid
+  metadata  Json?
+  createdAt DateTime            @default(now())
+
+  @@index([eventType, createdAt])
+  @@index([route])
 }


### PR DESCRIPTION
## Summary
- add a TelemetryEvent Prisma model and migration to capture page views
- implement helpers to record page views and compute analytics for job success rates
- render a dashboard telemetry snapshot card with engagement and success metrics

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e469eb25108333a7353d2dd933234e